### PR TITLE
fix: relax gleam_http requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
+# v3.0.1
+
+- Relaxed `gleam_http` constraint to permit v4
+
 # v3.0.0
+
 - Bump `stdlib` requirement to >=0.44.0
 
 # v2.0.0
+
 - Reorganized the modules
 - Added some HTTP stuff
 - Fixed some bugs with websocket stuff
 
 # v1.1.0
+
 - Proper HTTP request / response parsing
 - Better WebSocket message aggregation
 - Some actual tests!
 
 # v1.0.0
+
 - Initial release
 - Support for rudimentary HTTP parsing / encoding
 - Support for WebSocket frames (mostly)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gramps"
-version = "3.0.0"
+version = "3.0.1"
 description = "A Gleam HTTP and WebSocket helper library"
 
 licences = ["Apache-2.0"]
@@ -7,7 +7,7 @@ repository = { type = "github", user = "rawhat", repo = "gramps" }
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 1.0.0"
-gleam_http = ">= 3.6.0 and < 4.0.0"
+gleam_http = ">= 3.6.0 and < 5.0.0"
 gleam_crypto = ">= 1.3.0 and < 2.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,15 +3,15 @@
 
 packages = [
   { name = "gleam_crypto", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "8AE56026B3E05EBB1F076778478A762E9EB62B31AEEB4285755452F397029D22" },
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_http", version = "3.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8A70D2F70BB7CFEB5DF048A2183FFBA91AF6D4CF5798504841744A16999E33D2" },
-  { name = "gleam_stdlib", version = "0.46.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53940A91251A6BE9AEBB959D46E1CB45B510551D81342A52213850947732D4AB" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
+  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
+  { name = "gleam_stdlib", version = "0.54.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "723BA61A2BAE8D67406E59DD88CEA1B3C3F266FC8D70F64BE9FEC81B4505B927" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
 gleam_crypto = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
-gleam_http = { version = ">= 3.6.0 and < 4.0.0" }
+gleam_http = { version = ">= 3.6.0 and < 5.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gramps/http.gleam
+++ b/src/gramps/http.gleam
@@ -97,7 +97,7 @@ pub fn read_request(
             |> string.split_once("?")
             |> result.map(fn(pair) { #(pair.0, Some(pair.1)) })
             |> result.unwrap(#(path, None))
-          let method = http.method_from_dynamic(dynamic.from(method))
+          let method = http.parse_method(method)
           Ok(#(
             Request(
               body: Nil,


### PR DESCRIPTION
This PR is to support the changes from gleam_http by relaxing the requirement and changing the function http.method_from_dynamic(dynamic.from()) to use http.parse_method


I was inspired to do this pr since I keep seeing the "Command failed: gleam deps update gleam_http" in my proyects and I saw that lpil did a similar commit to mist.